### PR TITLE
Fixes for examples

### DIFF
--- a/examples/RF24/AcknowledgementPayloads/AcknowledgementPayloads.ino
+++ b/examples/RF24/AcknowledgementPayloads/AcknowledgementPayloads.ino
@@ -13,6 +13,9 @@
  */
 
 #include "nrf_to_nrf.h"
+#ifndef __MBED__
+#include "Adafruit_TinyUSB.h" //Needed for Serial.print on non-MBED enabled core
+#endif
 
 // instantiate an object for the nRF24L01 transceiver
 nrf_to_nrf radio;  // using pin 7 for the CE pin, and pin 8 for the CSN pin

--- a/examples/RF24/GettingStarted/GettingStarted.ino
+++ b/examples/RF24/GettingStarted/GettingStarted.ino
@@ -11,6 +11,9 @@
  * Use the Serial Monitor to change each node's behavior.
  */
 #include "nrf_to_nrf.h"
+#ifndef __MBED__
+#include "Adafruit_TinyUSB.h" //Needed for Serial.print on non-MBED enabled core
+#endif
 
 // instantiate an object for the nRF24L01 transceiver
 nrf_to_nrf radio;  // using pin 7 for the CE pin, and pin 8 for the CSN pin

--- a/examples/RF24/GettingStartedEncryption/GettingStartedEncryption.ino
+++ b/examples/RF24/GettingStartedEncryption/GettingStartedEncryption.ino
@@ -11,6 +11,9 @@
  * Use the Serial Monitor to change each node's behavior.
  */
 #include "nrf_to_nrf.h"
+#ifndef __MBED__
+#include "Adafruit_TinyUSB.h" //Needed for Serial.print on non-MBED enabled core
+#endif
 
 uint8_t myKey[16] = {1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6};
 

--- a/examples/RF24/scanner/scanner.ino
+++ b/examples/RF24/scanner/scanner.ino
@@ -23,7 +23,9 @@
  */
 
 #include "nrf_to_nrf.h"
-
+#ifndef __MBED__
+#include "Adafruit_TinyUSB.h" //Needed for Serial.print on non-MBED enabled core
+#endif
 //
 // Hardware configuration
 //
@@ -49,8 +51,6 @@ void setup(void) {
   //
 
   Serial.begin(115200);
-  delay(5000);
-  printf_begin();
   Serial.println(F("\n\rRF24/examples/scanner/"));
 
   //
@@ -95,7 +95,7 @@ void loop(void) {
   // Configure the channel and power level below
   if (Serial.available()) {
     char c = Serial.read();
-    if (c == 'g') {
+    if (c == 'g') {  //CC Mode not available on NRF52 boards
       constCarrierMode = 1;
       radio.stopListening();
       delay(2);

--- a/examples/RF24Ethernet/mqtt_basic/mqtt_basic.ino
+++ b/examples/RF24Ethernet/mqtt_basic/mqtt_basic.ino
@@ -35,6 +35,9 @@
 #include <RF24Mesh.h>
 #include <RF24Ethernet.h>
 #include <MQTT.h>
+#ifndef __MBED__
+#include "Adafruit_TinyUSB.h" //Needed for Serial.print on non-MBED enabled core
+#endif
 
 nrf_to_nrf radio;
 RF52Network network(radio);

--- a/examples/RF24Mesh/RF24Mesh_Example/RF24Mesh_Example.ino
+++ b/examples/RF24Mesh/RF24Mesh_Example/RF24Mesh_Example.ino
@@ -10,6 +10,9 @@
 #include "nrf_to_nrf.h"
 #include "RF24Network.h"
 #include "RF24Mesh.h"
+#ifndef __MBED__
+#include "Adafruit_TinyUSB.h" //Needed for Serial.print on non-MBED enabled core
+#endif
 
 /**** Configure the nrf24l01 CE and CS pins ****/
 nrf_to_nrf radio;

--- a/examples/RF24Mesh/RF24Mesh_ExampleEncryption/RF24Mesh_ExampleEncryption.ino
+++ b/examples/RF24Mesh/RF24Mesh_ExampleEncryption/RF24Mesh_ExampleEncryption.ino
@@ -10,6 +10,9 @@
 #include "nrf_to_nrf.h"
 #include "RF24Network.h"
 #include "RF24Mesh.h"
+#ifndef __MBED__
+#include "Adafruit_TinyUSB.h" //Needed for Serial.print on non-MBED enabled core
+#endif
 
 //Set up our encryption key
 uint8_t myKey[16] = {1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6};

--- a/examples/RF24Mesh/RF24Mesh_Example_MasterEncryption/RF24Mesh_Example_MasterEncryption.ino
+++ b/examples/RF24Mesh/RF24Mesh_Example_MasterEncryption/RF24Mesh_Example_MasterEncryption.ino
@@ -17,6 +17,9 @@
 #include "nrf_to_nrf.h"
 #include "RF24Network.h"
 #include "RF24Mesh.h"
+#ifndef __MBED__
+#include "Adafruit_TinyUSB.h" //Needed for Serial.print on non-MBED enabled core
+#endif
 
 //Set up our encryption key
 uint8_t myKey[16] = {1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6};

--- a/examples/RF24Network/helloworld_rx/helloworld_rx.ino
+++ b/examples/RF24Network/helloworld_rx/helloworld_rx.ino
@@ -17,7 +17,9 @@
 
 #include <nrf_to_nrf.h>
 #include <RF24Network.h>
-
+#ifndef __MBED__
+#include "Adafruit_TinyUSB.h" //Needed for Serial.print on non-MBED enabled core
+#endif
 
 nrf_to_nrf radio;  // nRF24L01(+) radio attached using Getting Started board
 

--- a/examples/RF24Network/helloworld_rxEncryption/helloworld_rxEncryption.ino
+++ b/examples/RF24Network/helloworld_rxEncryption/helloworld_rxEncryption.ino
@@ -17,6 +17,9 @@
 
 #include <nrf_to_nrf.h>
 #include <RF24Network.h>
+#ifndef __MBED__
+#include "Adafruit_TinyUSB.h" //Needed for Serial.print on non-MBED enabled core
+#endif
 
 //Set up our encryption key
 uint8_t myKey[16] = {1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6};

--- a/examples/RF24Network/helloworld_tx/helloworld_tx.ino
+++ b/examples/RF24Network/helloworld_tx/helloworld_tx.ino
@@ -17,6 +17,9 @@
 
 #include <nrf_to_nrf.h>
 #include <RF24Network.h>
+#ifndef __MBED__
+#include "Adafruit_TinyUSB.h" //Needed for Serial.print on non-MBED enabled core
+#endif
 
 nrf_to_nrf radio;  // nRF24L01(+) radio attached using Getting Started board
 

--- a/examples/RF24Network/helloworld_txEncryption/helloworld_txEncryption.ino
+++ b/examples/RF24Network/helloworld_txEncryption/helloworld_txEncryption.ino
@@ -17,6 +17,9 @@
 
 #include <nrf_to_nrf.h>
 #include <RF24Network.h>
+#ifndef __MBED__
+#include "Adafruit_TinyUSB.h" //Needed for Serial.print on non-MBED enabled core
+#endif
 
 //Set up our encryption key
 uint8_t myKey[16] = {1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6};


### PR DESCRIPTION
Add
```
#ifndef __MBED__
#include "Adafruit_TinyUSB.h" //Needed for Serial.print on non-MBED enabled core
#endif
```
To all examples