### PR TITLE
Fixes are in (Serial & Scanner)

### DIFF
--- a/examples/RF24/scanner/scanner.ino
+++ b/examples/RF24/scanner/scanner.ino
@@ -49,8 +49,6 @@ void setup(void) {
   //
 
   Serial.begin(115200);
-  delay(5000);
-  printf_begin();
   Serial.println(F("\n\rRF24/examples/scanner/"));
 
   //

--- a/src/nrf_to_nrf.h
+++ b/src/nrf_to_nrf.h
@@ -7,6 +7,9 @@
 #ifndef __nrf52840_nrf24l01_H__
 #define __nrf52840_nrf24l01_H__
 #include <Arduino.h>
+#ifndef __MBED__
+#include "Adafruit_TinyUSB.h" //Needed for Serial.print on non-MBED enabled core
+#endif
 
 #define NRF52_RADIO_LIBRARY
 #define DEFAULT_MAX_PAYLOAD_SIZE 32

--- a/src/nrf_to_nrf.h
+++ b/src/nrf_to_nrf.h
@@ -7,8 +7,9 @@
 #ifndef __nrf52840_nrf24l01_H__
 #define __nrf52840_nrf24l01_H__
 #include <Arduino.h>
-#ifndef __MBED__
-#include "Adafruit_TinyUSB.h" //Needed for Serial.print on non-MBED enabled core
+#if !defined(__MBED__) || defined(USE_TINYUSB)
+// Needed for Serial.print on non-MBED enabled or adafruit-based nRF52 cores
+#include "Adafruit_TinyUSB.h" 
 #endif
 
 #define NRF52_RADIO_LIBRARY


### PR DESCRIPTION
- Fix scanner example
- Include Adafruit_TinyUSB.h for non-mbed cores in nrf_to_nrf.h for `Serial.print`