### PR TITLE
Do not set LFCLKSRC as it will hang if no external crystal is present

### DIFF
--- a/src/nrf_to_nrf.cpp
+++ b/src/nrf_to_nrf.cpp
@@ -90,10 +90,10 @@ bool nrf_to_nrf::begin()
         // Do nothing.
     }
 
-    NRF_CLOCK->LFCLKSRC = (CLOCK_LFCLKSRC_SRC_Xtal << CLOCK_LFCLKSRC_SRC_Pos);
     NRF_CLOCK->EVENTS_LFCLKSTARTED = 0;
     NRF_CLOCK->TASKS_LFCLKSTART = 1;
 
+    /* Wait for the low frequency clock to start up */
     while (NRF_CLOCK->EVENTS_LFCLKSTARTED == 0) {
         // Do nothing.
     }


### PR DESCRIPTION
If a board does not have a crystal attached for the LF clock (e.g. because it uses the internal RC oscillator), setting `NRF_CLOCK->LFCLKSRC = (CLOCK_LFCLKSRC_SRC_Xtal << CLOCK_LFCLKSRC_SRC_Pos)` will cause `while (NRF_CLOCK->EVENTS_LFCLKSTARTED == 0)` to loop forever.
The source of the LF oscillator should be set outside of this library.