### PR TITLE
Static payload with no ack does not have packet counter

### DIFF
--- a/src/nrf_to_nrf.cpp
+++ b/src/nrf_to_nrf.cpp
@@ -272,16 +272,17 @@ bool nrf_to_nrf::available(uint8_t* pipe_num)
             }
             NRF_RADIO->TXADDRESS = txAddress;
             startListening(false);
+
+            // If the packet has the same ID number and data, it is most likely a
+            // duplicate
+            if(NRF_RADIO->CRCCNF != 0) { //If CRC enabled, check this data
+                if (packetCtr == lastPacketCounter && packetData == lastData) {
+                    NRF_RADIO->TASKS_START = 1;
+                    return 0;
+                }
+            }
         }
 
-        // If the packet has the same ID number and data, it is most likely a
-        // duplicate
-        if(NRF_RADIO->CRCCNF != 0){ //If CRC enabled, check this data
-          if (packetCtr == lastPacketCounter && packetData == lastData) {
-            NRF_RADIO->TASKS_START = 1;
-            return 0;
-          }
-        }
 #if defined CCM_ENCRYPTION_ENABLED
         if (enableEncryption) {
             ccmData.counter = counter;


### PR DESCRIPTION
If static payload size is used instead of dynamic payload size and acks are not enabled, then there will not be a packet counter (PID) in the message. At the moment the available() method expects that a packet counter is present whenever CRC is enabled which is not the case. This will erroneously discard all messages that are equal to the last message sent.

As I am not using data acks I am not sure if this patch works correctly in all cases the check is required (dynamic payload with ack, static payload with ack).