### PR TITLE
Do not enforce tinyusb for serial if _MBED_ is not defined

### DIFF
--- a/src/nrf_to_nrf.h
+++ b/src/nrf_to_nrf.h
@@ -7,7 +7,7 @@
 #ifndef __nrf52840_nrf24l01_H__
 #define __nrf52840_nrf24l01_H__
 #include <Arduino.h>
-#if !defined(__MBED__) || defined(USE_TINYUSB)
+#if defined(USE_TINYUSB)
 // Needed for Serial.print on non-MBED enabled or adafruit-based nRF52 cores
 #include "Adafruit_TinyUSB.h" 
 #endif


### PR DESCRIPTION
With the nordicnrf52 platform and arduino framework selected on Platform.io, the https://github.com/sandeepmistry/arduino-nRF5 core is used. This already contains an implementation for Serial.print in cores/nRF5/Print.cpp.

As __MBED__ is not defined in this core the "#if !defined(__MBED__) || defined(USE_TINYUSB)" will try to include the Adafruit_TinyUSB.h header which is not present (and not required) in this case.

A simple fix would be to remove the incorrect "!defined(__MBED__)". If there are cores that require tinyUSB for Serial.print then they probably already define USE_TINYUSB.