### PR TITLE
Adjust ack timeouts

### DIFF
--- a/src/nrf_to_nrf.h
+++ b/src/nrf_to_nrf.h
@@ -19,9 +19,9 @@
 #define NRF52_RADIO_LIBRARY
 #define DEFAULT_MAX_PAYLOAD_SIZE 32
 #define ACTUAL_MAX_PAYLOAD_SIZE  127
-#define ACK_TIMEOUT_1MBPS        500 // 200 with static payloads
-#define ACK_TIMEOUT_2MBPS        300 // 165 with static payloads
-#define ACK_TIMEOUT_250KBPS      500
+#define ACK_TIMEOUT_1MBPS        600 // 300 with static payloads
+#define ACK_TIMEOUT_2MBPS        400 // 265 with static payloads
+#define ACK_TIMEOUT_250KBPS      800 // 500 with staticPayloads
 #define ACK_TIMEOUT_1MBPS_OFFSET 300
 #define ACK_TIMEOUT_2MBPS_OFFSET 135
 #define ACK_TIMEOUT_250KBPS_OFFSET 300


### PR DESCRIPTION
- How long the radio waits for ACKs is fairly important and needs to be long enough for the responding radio to switch into TX mode and respond with an ACK. These can be lowered if sending small payloads. Tested with max payload sizes + encryption.