### PR TITLE
Fix encryption

### DIFF
--- a/src/nrf_to_nrf.cpp
+++ b/src/nrf_to_nrf.cpp
@@ -1381,7 +1381,6 @@ uint8_t nrf_to_nrf::decrypt(void* bufferIn, uint8_t size)
     NRF_CCM->EVENTS_ENDKSGEN = 0;
     NRF_CCM->EVENTS_ENDCRYPT = 0;
     NRF_CCM->TASKS_KSGEN = 1;
-    NRF_CCM->TASKS_KSGEN = 1;
 
     while (!NRF_CCM->EVENTS_ENDCRYPT) {
     };

--- a/src/nrf_to_nrf.cpp
+++ b/src/nrf_to_nrf.cpp
@@ -225,10 +225,10 @@ bool nrf_to_nrf::available(uint8_t* pipe_num)
 #if defined CCM_ENCRYPTION_ENABLED
             if (enableEncryption) {
                 if (DPL) {
-                    memcpy(&rxBuffer[1], &radioData[2 + CCM_IV_SIZE + CCM_COUNTER_SIZE], max(0, radioData[0] - CCM_IV_SIZE - CCM_COUNTER_SIZE - CCM_MIC_SIZE));
+                    memcpy(&rxBuffer[1], &radioData[2 + CCM_IV_SIZE + CCM_COUNTER_SIZE], max(0, radioData[0] - CCM_IV_SIZE - CCM_COUNTER_SIZE));
                 }
                 else {
-                    memcpy(&rxBuffer[1], &radioData[2 + CCM_IV_SIZE + CCM_COUNTER_SIZE], max(0, staticPayloadSize - CCM_IV_SIZE - CCM_COUNTER_SIZE - CCM_MIC_SIZE));
+                    memcpy(&rxBuffer[1], &radioData[2 + CCM_IV_SIZE + CCM_COUNTER_SIZE], max(0, staticPayloadSize - CCM_IV_SIZE - CCM_COUNTER_SIZE));
                 }
                 memcpy(tmpIV, &radioData[2], CCM_IV_SIZE);
                 memcpy(&counter, &radioData[2 + CCM_IV_SIZE], CCM_COUNTER_SIZE);
@@ -245,14 +245,16 @@ bool nrf_to_nrf::available(uint8_t* pipe_num)
             }
 #endif
         }
-        rxBuffer[0] = radioData[0];
+        
         rxFifoAvailable = true;
         uint8_t packetCtr = 0;
         if (DPL) {
             packetCtr = radioData[1];
+            rxBuffer[0] = radioData[0];
         }
         else {
             packetCtr = radioData[0];
+            rxBuffer[0] = staticPayloadSize;
         }
 
         ackPID = packetCtr;
@@ -1326,7 +1328,8 @@ void nrf_to_nrf::printDetails()
 
 uint8_t nrf_to_nrf::encrypt(void* bufferIn, uint8_t size)
 {
-
+    NRF_CCM->MODE = 0 | 1 << 24 | 1 << 16;
+    
     if (!size) {
         return 0;
     }
@@ -1358,7 +1361,8 @@ uint8_t nrf_to_nrf::encrypt(void* bufferIn, uint8_t size)
 
 uint8_t nrf_to_nrf::decrypt(void* bufferIn, uint8_t size)
 {
-
+    NRF_CCM->MODE = 1 | 1 << 24 | 1 << 16;
+    
     if (!size) {
         return 0;
     }
@@ -1377,13 +1381,19 @@ uint8_t nrf_to_nrf::decrypt(void* bufferIn, uint8_t size)
     NRF_CCM->EVENTS_ENDKSGEN = 0;
     NRF_CCM->EVENTS_ENDCRYPT = 0;
     NRF_CCM->TASKS_KSGEN = 1;
+    NRF_CCM->TASKS_KSGEN = 1;
 
     while (!NRF_CCM->EVENTS_ENDCRYPT) {
     };
-
+    
     if (NRF_CCM->EVENTS_ERROR) {
         return 0;
     }
+    
+    if(NRF_CCM->MICSTATUS == (CCM_MICSTATUS_MICSTATUS_CheckFailed << CCM_MICSTATUS_MICSTATUS_Pos)){
+        return 0;
+    }
+    
     return outBuffer[1];
 }
 


### PR DESCRIPTION
- MAC/MIC authentication was not being checked and was failing
- Calculate correct size to copy to internal rxBuffer
- set length of packet based on incoming size (DPL) or static side (No DPL)
- Properly configure the encryption modes - encryption or decryption enable
- Verify MAC/MIC status after decryption