### PR TITLE
Add new stopListening function

### DIFF
--- a/src/nrf_to_nrf.cpp
+++ b/src/nrf_to_nrf.cpp
@@ -733,6 +733,15 @@ void nrf_to_nrf::stopListening(bool setWritingPipe, bool resetAddresses)
 
 /**********************************************************************************************************/
 
+void nrf_to_nrf::stopListening(const uint8_t* txAddress, bool setWritingPipe, bool resetAddresses)
+{
+
+    stopListening();
+    openWritingPipe(txAddress);
+}
+
+/**********************************************************************************************************/
+
 uint8_t nrf_to_nrf::getDynamicPayloadSize()
 {
     uint8_t size = min(staticPayloadSize, rxBuffer[0]);

--- a/src/nrf_to_nrf.h
+++ b/src/nrf_to_nrf.h
@@ -172,6 +172,8 @@ public:
      */
     void stopListening(bool setWritingPipe = true, bool resetAddresses = true);
 
+    void stopListening(const uint8_t* txAddress, bool setWritingPipe = true, bool resetAddresses = true);
+
     /**
      * Same as NRF24 except the 52840 has 8 pipes
      */


### PR DESCRIPTION
- The recent changes to RF24Network require a new stopListening function in line with RF24 core library
- 