### PR TITLE
Add frequency map option - Allows channels ranging from 2360Mhz to 2500MHz

### DIFF
--- a/src/nrf_to_nrf.cpp
+++ b/src/nrf_to_nrf.cpp
@@ -764,7 +764,7 @@ bool nrf_to_nrf::isValid()
 
 /**********************************************************************************************************/
 
-void nrf_to_nrf::setChannel(uint8_t channel) { NRF_RADIO->FREQUENCY = channel; }
+void nrf_to_nrf::setChannel(uint8_t channel, bool map) { NRF_RADIO->FREQUENCY = channel | map << RADIO_FREQUENCY_MAP_Pos; }
 
 /**********************************************************************************************************/
 

--- a/src/nrf_to_nrf.h
+++ b/src/nrf_to_nrf.h
@@ -251,7 +251,9 @@ public:
     bool isValid();
 
     /**
-     * Same as NRF24
+     * Same as NRF24, except we can map the channels lower
+     * @param channel Set 0 to 100 for 2400-2500Mhz if map == 0, 2360-2460Mhz if map == 1
+     * @param map 1 is low range (2360-2460Mhz), 0 is high range (2400-2500Mhz)
      */
     void setChannel(uint8_t channel, bool map = 0);
 

--- a/src/nrf_to_nrf.h
+++ b/src/nrf_to_nrf.h
@@ -253,7 +253,7 @@ public:
     /**
      * Same as NRF24
      */
-    void setChannel(uint8_t channel);
+    void setChannel(uint8_t channel, bool map = 0);
 
     /**
      * Same as NRF24


### PR DESCRIPTION
1. Frequency can be set 0 to 100
2. Default is Frequency = 2400 + FREQUENCY (MHz)

MAP Channel map selection:
Default 0 Channel map between 2400 MHZ .. 2500 MHz Frequency = 2400 + FREQUENCY (MHz)
Low 1 Channel map between 2360 MHZ .. 2460 MHz
Frequency = 2360 + FREQUENCY (MHz)

So basically, if you call setChannel(100,1); on the nRF52x, then on the NRF24 you need to call setChannel(60);

Didn't exactly realize this before, but the nRF24s operate up to 2400-2525MHz, so there are 25 channels that won't work with the nRF52s
