### PR TITLE
Use interframe spacing (TIFS) feature of radio

### DIFF
--- a/src/nrf_to_nrf.cpp
+++ b/src/nrf_to_nrf.cpp
@@ -72,6 +72,7 @@ nrf_to_nrf::nrf_to_nrf()
     ackTimeout = ACK_TIMEOUT_1MBPS;
     payloadAvailable = false;
     enableEncryption = false;
+    interframeSpacing = 115;
 
 #if defined CCM_ENCRYPTION_ENABLED
     NRF_CCM->INPTR = (uint32_t)inBuffer;

--- a/src/nrf_to_nrf.h
+++ b/src/nrf_to_nrf.h
@@ -442,7 +442,7 @@ public:
      *
      * This is configured for compatibility with nRF24L01 radios. Can be set lower if communicating between nRF52x devices.
      */
-    uint16_t interframeSpacing = 115;
+    uint16_t interframeSpacing;
 
 #ifdef NRF_HAS_ENERGY_DETECT
     uint8_t sample_ed(void);


### PR DESCRIPTION
- Use TIFS to delay slightly between consecutively transmitted payloads.
> The IEEE 802.15.4 standard defines a specific time that is alotted for the MAC sublayer to process received
data. Usage of this interframe spacing (IFS) comes into play to avoid that two frames are transmitted too
close to eachother in time.

- Compatibility with nRF24L01
- Add `interframeSpacing` variable so users can control the delay as required
- The following changes would no longer be needed: 
https://github.com/nRF24/RF24Network/pull/254