### PR TITLE
Fixes for nRF54l15

### DIFF
--- a/src/nrf_to_nrf.cpp
+++ b/src/nrf_to_nrf.cpp
@@ -382,10 +382,9 @@ bool nrf_to_nrf::write(void* buf, uint8_t len, bool multicast, bool doEncryption
 #ifdef ARDUINO_NRF54L15
     uint32_t timeout = millis();
     while (NRF_RADIO->STATE != 10) {
-        __WFE;
+        __WFE();
         if (millis() > timeout + 250) {
-            stopListening();
-            break;
+            return 0;
         }
     }
 #endif
@@ -757,12 +756,14 @@ void nrf_to_nrf::stopListening(bool setWritingPipe, bool resetAddresses)
 #ifndef ARDUINO_NRF54L15
         NRF_RADIO->MODECNF0 = 0x200;
 #else
-        NRF_RADIO->TIMING = 0x1;
+        NRF_RADIO->TIMING = 0x0;
 #endif
     }
-
+#ifndef ARDUINO_NRF54L15
     NRF_RADIO->SHORTS = 0x6;
-
+#else
+    NRF_RADIO->SHORTS = 0x100008;
+#endif
     if (NRF_RADIO->STATE < 9) {
         NRF_RADIO->EVENTS_TXREADY = 0;
         NRF_RADIO->TASKS_TXEN = 1;

--- a/src/nrf_to_nrf.h
+++ b/src/nrf_to_nrf.h
@@ -208,8 +208,8 @@ public:
 
     /**
      * Data buffer for radio data
-     * The radio can handle packets up to 127 bytes if CRC & DPL is disabled
-     * 125 bytes if using 16-bit CRC & DPL is disabled
+     * The radio can handle packets up to 255 bytes if CRC & DPL is disabled
+     * 254 bytes if using 16-bit CRC & DPL is disabled
      *
      */
     uint8_t radioData[ACTUAL_MAX_PAYLOAD_SIZE + 2];
@@ -315,8 +315,8 @@ public:
     void disableDynamicPayloads();
 
     /**
-     * NRF52840 will handle up to 127 byte payloads with CRC & DPL disabled, 125 with 16-bit CRC and DPL disabled
-     * NRF54L15 will handle up to 255 byte payloads
+     * NRF52840 will handle up to 255 byte payloads with CRC & DPL disabled, 254 with 16-bit CRC and DPL
+     * NRF54L15 will do the same
      */
     void setPayloadSize(uint8_t size);
 


### PR DESCRIPTION
- Return false if not in TX_IDLE state upon calls to write()
- Set NRF_RADIO_TIMING register properly for legacy ramp-up time
- Enable the proper shortcuts to enable and enforce TIFS (interframe spacing)
- Correct docs to say 254 byte payloads are the max with ESB+AA