### PR TITLE
nRF54L15 fixes

### DIFF
--- a/src/nrf_to_nrf.cpp
+++ b/src/nrf_to_nrf.cpp
@@ -98,7 +98,6 @@ nrf_to_nrf::nrf_to_nrf()
     arcCounter = 0;
     ackTimeout = ACK_TIMEOUT_1MBPS;
     payloadAvailable = false;
-    
     #ifndef ARDUINO_NRF54L15
     interframeSpacing = 115;
     #else

--- a/src/nrf_to_nrf.cpp
+++ b/src/nrf_to_nrf.cpp
@@ -98,7 +98,12 @@ nrf_to_nrf::nrf_to_nrf()
     arcCounter = 0;
     ackTimeout = ACK_TIMEOUT_1MBPS;
     payloadAvailable = false;
+    
+    #ifndef ARDUINO_NRF54L15
     interframeSpacing = 115;
+    #else
+    interframeSpacing = 130;
+    #endif
 
 #if defined CCM_ENCRYPTION_ENABLED
     NRF_CCM->INPTR = (uint32_t)inBuffer;
@@ -390,15 +395,6 @@ void nrf_to_nrf::read(void* buf, uint8_t len)
 
 bool nrf_to_nrf::write(void* buf, uint8_t len, bool multicast, bool doEncryption)
 {
-#ifdef ARDUINO_NRF54L15
-    uint32_t timeout = millis();
-    while (NRF_RADIO->STATE != 10) {
-        yield();
-        if (millis() - timeout > 250) {
-            return 0;
-        }
-    }
-#endif
 
     uint8_t PID = ackPID;
     if (DPL) {
@@ -778,7 +774,7 @@ void nrf_to_nrf::stopListening(bool setWritingPipe, bool resetAddresses)
 #ifndef ARDUINO_NRF54L15
     NRF_RADIO->SHORTS = 0x6;
 #else
-    NRF_RADIO->SHORTS = 0x100008;
+    NRF_RADIO->SHORTS = 0x80004;
 #endif
     if (NRF_RADIO->STATE < 9) {
         NRF_RADIO->EVENTS_TXREADY = 0;


### PR DESCRIPTION
- Set interframe spacing to 130 for L15
- Remove timeout code in write as unnecessary now
- Fix calls to shorts to properly point to PHYEND_DISABLE and DISABLED_TXEN ( 0x80004 )